### PR TITLE
Adding Explanation to Merge Sort

### DIFF
--- a/algorithms.md
+++ b/algorithms.md
@@ -140,6 +140,7 @@ setSymmetricDifference(a, b)
 #### binarySearch
 
 Search for a number within an array using the **binary search** algorithm.
+[Binary Search](https://en.wikipedia.org/wiki/Binary_search_algorithm) looks for an item in a list by looking at a list's center, then looking at the center of the left or right half, continually dividing the search space in half until it finds what it's looking for.
 
 ```javascript
 const numbers = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50]


### PR DESCRIPTION
I have seen multiple examples from this week and previous weeks where people have failed to implement binary search, and just wrote something to pass the tests.  They will write simple linear search functions, and in one case, I saw someone straight up use `array.indexOf(item)`.

They appear to have looked at the example provided, saw what the function was expected to return, and not actually researched what Binary Search is.